### PR TITLE
Add --merged-pdf slidefactory feature to this repo.

### DIFF
--- a/.github/workflows/pages-build.yml
+++ b/.github/workflows/pages-build.yml
@@ -39,7 +39,7 @@ jobs:
           unzip update-theme.zip
 
           ARGS=""
-          [[ "$INCLUDE_PDF" == "true" ]] && ARGS="--with-pdf"
+          [[ "$INCLUDE_PDF" == "true" ]] && ARGS="--with-pdf --merge-pdf"
 
           slidefactory pages about.yml build \
               --filters tools/mpi_links.py \
@@ -52,7 +52,18 @@ jobs:
           # TODO: PR to slidefactory
           bash tools/patch-index-open.sh build/index.html
 
+          # Note that the merged PDF doesn't include Parallel Algorithms
+          if [[ "$INCLUDE_PDF" == "true" ]]; then
+              bash tools/patch-index-merged-pdf.sh build/index.html
+          fi
+
           # Fetch external slides
+          # TODO: This runs after slidefactory has already built
+          # build/slides-merged.pdf (see --merge-pdf above), so the merged
+          # PDF still has the placeholder link-slide for Parallel Algorithms
+          # instead of this externally-hosted deck. Fix once slidefactory
+          # supports building the merged PDF from an already-built output
+          # directory, or otherwise incorporating external slides into it.
           rm -rf build/*/algorithms/
           mkdir -p build/pdf/algorithms/
           wget https://a3s.fi/summerschool/assets/slides/parallel-algorithms.pdf -O build/pdf/algorithms/parallel-algorithms.pdf

--- a/global_title.md
+++ b/global_title.md
@@ -1,0 +1,12 @@
+<!--
+SPDX-FileCopyrightText: 2010 CSC - IT Center for Science Ltd. <www.csc.fi>
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+---
+title:  CSC Summer School in High-Performance Computing 2026
+event:  Merged pdf of all presentation slides for easy lookup
+lang:   en
+---
+

--- a/tools/patch-index-merged-pdf.sh
+++ b/tools/patch-index-merged-pdf.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 CSC - IT Center for Science Ltd. <www.csc.fi>
+#
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  echo "Error: no input file provided"
+  echo "Usage: $0 <html-file>"
+  exit 1
+fi
+
+INPUT_FILE="$1"
+
+if [[ ! -f "$INPUT_FILE" ]]; then
+  echo "Error: file '$INPUT_FILE' not found"
+  exit 1
+fi
+
+# TODO: The merged PDF is built (by slidefactory --merge-pdf) before the
+# "Fetch external slides" step below swaps in the externally-hosted Parallel
+# Algorithms deck, so that chapter only has its placeholder link-slide in the
+# merged PDF, not the real content. Note that on the download link, wherever
+# slidefactory places it, until this is fixed.
+echo "Warning: merged PDF does not include the externally-fetched Parallel Algorithms slides"
+
+perl -0777 -i -pe '
+s|(<c-link href="slides-merged\.pdf">Download a single merged PDF with a table of contents\.</c-link>)|$1 (Parallel Algorithms not included)|;
+' "$INPUT_FILE"
+
+echo "Patched: $INPUT_FILE"


### PR DESCRIPTION
Needs https://github.com/csc-training/slidefactory/pull/24 to work, will need editing the CI workflow here to get the updated container when it's done.

Note that the merged pdf does not include the external slides at the moment.